### PR TITLE
Structurelib and tooltip fixes

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -34,13 +34,13 @@
  * For more details, see https://docs.gradle.org/8.0.1/userguide/java_library_plugin.html#sec:java_library_configurations_graph
  */
 dependencies {
-    implementation("com.github.GTNewHorizons:NotEnoughItems:2.7.77-GTNH:dev")
-    implementation("com.github.GTNewHorizons:GTNHLib:0.6.39:dev")
-    compileOnly("com.github.GTNewHorizons:BetterQuesting:3.7.11-GTNH:dev")
-    implementation("com.github.GTNewHorizons:ModularUI2:2.2.18-1.7.10:dev")
-    // implementation("com.github.GTNewHorizons:ModularUI2:99.99:dev")
-    implementation("com.github.GTNewHorizons:StructureLib:1.4.18:dev")
-    implementation("com.github.GTNewHorizons:GT5-Unofficial:5.09.51.440:dev")
+    implementation("com.github.GTNewHorizons:NotEnoughItems:2.8.6-GTNH:dev")
+    implementation("com.github.GTNewHorizons:GTNHLib:0.7.0:dev")
+    compileOnly("com.github.GTNewHorizons:BetterQuesting:3.8.4-GTNH:dev")
+    implementation("com.github.GTNewHorizons:ModularUI2:2.2.20-1.7.10:dev")
+    // implementation("com.github.GTNewHorizons:ModularUI2:2.2.20-1.7.10:dev")
+    implementation("com.github.GTNewHorizons:StructureLib:1.4.23:dev")
+    implementation("com.github.GTNewHorizons:GT5-Unofficial:5.09.52.19:dev")
 }
 
 // deps may transitively add Baubles, so we replace it
@@ -49,7 +49,7 @@ project.getConfigurations()
         final DependencySubstitutions ds = c.getResolutionStrategy()
             .getDependencySubstitution()
         ds.substitute(ds.module("com.github.GTNewHorizons:Baubles"))
-            .using(ds.module("com.github.GTNewHorizons:Baubles-Expanded:2.1.9-GTNH"))
+            .using(ds.module("com.github.GTNewHorizons:Baubles-Expanded:2.2.0-GTNH"))
             .withClassifier("dev")
             .because("Baubles-Expanded replaces Baubles")
     })

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,5 +17,5 @@ pluginManagement {
 }
 
 plugins {
-    id("com.gtnewhorizons.gtnhsettingsconvention") version("1.0.41")
+    id("com.gtnewhorizons.gtnhsettingsconvention") version("1.0.43")
 }

--- a/src/main/java/com/cubefury/vendingmachine/blocks/MTEVendingMachine.java
+++ b/src/main/java/com/cubefury/vendingmachine/blocks/MTEVendingMachine.java
@@ -48,6 +48,7 @@ import com.cubefury.vendingmachine.trade.TradeManager;
 import com.cubefury.vendingmachine.trade.TradeRequest;
 import com.cubefury.vendingmachine.util.BigItemStack;
 import com.cubefury.vendingmachine.util.OverlayHelper;
+import com.cubefury.vendingmachine.util.Translator;
 import com.gtnewhorizon.structurelib.StructureLibAPI;
 import com.gtnewhorizon.structurelib.alignment.IAlignment;
 import com.gtnewhorizon.structurelib.alignment.IAlignmentLimits;
@@ -82,13 +83,13 @@ public class MTEVendingMachine extends MTEMultiBlockBase
         .addElement(
             'c',
             ofChain(
-                ofBlock(GregTechAPI.sBlockCasings11, 0),
                 ofHatchAdderOptional(
                     MTEVendingMachine::addUplinkHatch,
                     ((BlockCasings11) GregTechAPI.sBlockCasings11).getTextureIndex(0),
                     1,
                     GregTechAPI.sBlockCasings11,
-                    0)))
+                    0),
+                ofBlock(GregTechAPI.sBlockCasings11, 0)))
         .build();
 
     private final ArrayList<MTEVendingUplinkHatch> uplinkHatches = new ArrayList<>();
@@ -347,7 +348,7 @@ public class MTEVendingMachine extends MTEMultiBlockBase
 
     @Override
     public String[] getStructureDescription(ItemStack stackSize) {
-        return getTooltip().getStructureHint();
+        return new String[] { Translator.translate("structure.vendingmachine.hint.1") };
     }
 
     @Override

--- a/src/main/java/com/cubefury/vendingmachine/blocks/MTEVendingMachine.java
+++ b/src/main/java/com/cubefury/vendingmachine/blocks/MTEVendingMachine.java
@@ -5,6 +5,8 @@ import static com.cubefury.vendingmachine.api.enums.Textures.VM_MACHINE_FRONT_ON
 import static com.cubefury.vendingmachine.api.enums.Textures.VM_MACHINE_FRONT_ON_GLOW;
 import static com.cubefury.vendingmachine.api.enums.Textures.VM_OVERLAY;
 import static com.cubefury.vendingmachine.api.enums.Textures.VM_OVERLAY_ACTIVE;
+import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofBlock;
+import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofChain;
 import static gregtech.api.util.GTStructureUtility.ofHatchAdderOptional;
 
 import java.util.ArrayList;
@@ -79,12 +81,14 @@ public class MTEVendingMachine extends MTEMultiBlockBase
         .addShape("main", new String[][] { { "cc", "c~", "cc" } })
         .addElement(
             'c',
-            ofHatchAdderOptional(
-                MTEVendingMachine::addUplinkHatch,
-                ((BlockCasings11) GregTechAPI.sBlockCasings11).getTextureIndex(0),
-                1,
-                GregTechAPI.sBlockCasings11,
-                0))
+            ofChain(
+                ofBlock(GregTechAPI.sBlockCasings11, 0),
+                ofHatchAdderOptional(
+                    MTEVendingMachine::addUplinkHatch,
+                    ((BlockCasings11) GregTechAPI.sBlockCasings11).getTextureIndex(0),
+                    1,
+                    GregTechAPI.sBlockCasings11,
+                    0)))
         .build();
 
     private final ArrayList<MTEVendingUplinkHatch> uplinkHatches = new ArrayList<>();
@@ -359,6 +363,7 @@ public class MTEVendingMachine extends MTEMultiBlockBase
                 .beginStructureBlock(2, 3, 1, false)
                 .addController("Middle")
                 .addOtherStructurePart("Tin Item Pipe Casings", "Everything except the controller")
+                .addOtherStructurePart("ME Vending Uplink Hatch", "Any Pipe Casing, Optional")
                 .addStructureInfo("Cannot be flipped onto its side")
                 .toolTipFinisher();
         }

--- a/src/main/java/com/cubefury/vendingmachine/blocks/gui/MTEVendingMachineGui.java
+++ b/src/main/java/com/cubefury/vendingmachine/blocks/gui/MTEVendingMachineGui.java
@@ -268,7 +268,7 @@ public class MTEVendingMachineGui extends MTEMultiBlockBaseGui {
                         .width(30)
                         .height(20))
                     .child(
-                        new Row().child(createInputRow().center())
+                        new Row().child(createInputSlots().center())
                             .top(20)
                             .height(18 * 3))
                     .child(
@@ -299,7 +299,7 @@ public class MTEVendingMachineGui extends MTEMultiBlockBaseGui {
                     .right(1));
     }
 
-    private SlotGroupWidget createInputRow() {
+    private SlotGroupWidget createInputSlots() {
         return SlotGroupWidget.builder()
             .matrix("II", "II", "II")
             .key('I', index -> {
@@ -336,11 +336,6 @@ public class MTEVendingMachineGui extends MTEMultiBlockBaseGui {
         return SlotGroupWidget.builder()
             .matrix("II", "II", "II")
             .key('I', index -> {
-                /*
-                 * ModularSlot ms = new ModularSlot(base.outputItems, index).accessibility(false, true)
-                 * .slotGroup("outputSlotGroup");
-                 */
-                // ms.changeListener((newItem, onlyAmountChanged, client, init) -> {});
                 return new ItemSlot().slot(
                     new ModularSlot(base.outputItems, index).accessibility(false, true)
                         .slotGroup("outputSlotGroup"));
@@ -493,8 +488,8 @@ public class MTEVendingMachineGui extends MTEMultiBlockBaseGui {
     @Override
     protected void registerSyncValues(PanelSyncManager syncManager) {
         super.registerSyncValues(syncManager);
-        syncManager.registerSlotGroup("inputSlotGroup", 6, true);
-        syncManager.registerSlotGroup("outputSlotGroup", 4, false);
+        syncManager.registerSlotGroup("inputSlotGroup", 2, true);
+        syncManager.registerSlotGroup("outputSlotGroup", 2, false);
 
         BooleanSyncValue ejectItemsSyncer = new BooleanSyncValue(() -> this.ejectItems, val -> {
             this.ejectItems = val;

--- a/src/main/java/com/cubefury/vendingmachine/blocks/gui/MTEVendingMachineGui.java
+++ b/src/main/java/com/cubefury/vendingmachine/blocks/gui/MTEVendingMachineGui.java
@@ -128,7 +128,7 @@ public class MTEVendingMachineGui extends MTEMultiBlockBaseGui {
         panel.child(
             new Column().size(20)
                 .right(5));
-        panel.child(createIOColumn(syncManager));
+        panel.child(createIOColumn());
         return panel;
     }
 
@@ -253,7 +253,7 @@ public class MTEVendingMachineGui extends MTEMultiBlockBaseGui {
         ejectItems = false;
     }
 
-    private IWidget createIOColumn(PanelSyncManager syncManager) {
+    private IWidget createIOColumn() {
         return new ParentWidget<>().excludeAreaInNEI()
             .width(50)
             .height(178)
@@ -336,10 +336,14 @@ public class MTEVendingMachineGui extends MTEMultiBlockBaseGui {
         return SlotGroupWidget.builder()
             .matrix("II", "II", "II")
             .key('I', index -> {
-                ModularSlot ms = new ModularSlot(base.outputItems, index).accessibility(false, true)
-                    .slotGroup("outputSlotGroup");
-                ms.changeListener((newItem, onlyAmountChanged, client, init) -> {});
-                return new ItemSlot().slot(ms);
+                /*
+                 * ModularSlot ms = new ModularSlot(base.outputItems, index).accessibility(false, true)
+                 * .slotGroup("outputSlotGroup");
+                 */
+                // ms.changeListener((newItem, onlyAmountChanged, client, init) -> {});
+                return new ItemSlot().slot(
+                    new ModularSlot(base.outputItems, index).accessibility(false, true)
+                        .slotGroup("outputSlotGroup"));
             })
             .build();
     }
@@ -388,6 +392,7 @@ public class MTEVendingMachineGui extends MTEMultiBlockBaseGui {
 
                                     builder.emptyLine();
                                     builder.addLine(IKey.str(cur.label).style(IKey.GRAY));
+                                    builder.addLine(IKey.str(Translator.translate("vendingmachine.gui.trade_hint")).style(IKey.GRAY));
                                 }
                             }
                         }

--- a/src/main/resources/assets/vendingmachine/lang/en_US.lang
+++ b/src/main/resources/assets/vendingmachine/lang/en_US.lang
@@ -2,6 +2,8 @@ item.vendingmachine.placeholder.name=Placeholder Item
 
 tooltip.vendingmachine=Who's even restocking this...
 
+structure.vendingmachine.hint.1=Hint 1 Dot: Tin Item Pipe Casing, ME Vending Uplink Hatch
+
 vendingmachine.gui.requirementHeader=Requirements:
 vendingmachine.gui.requirement.unknown=Unknown Requirement
 vendingmachine.gui.requirement.betterquesting=Quest

--- a/src/main/resources/assets/vendingmachine/lang/en_US.lang
+++ b/src/main/resources/assets/vendingmachine/lang/en_US.lang
@@ -14,6 +14,7 @@ vendingmachine.gui.coin_eject=Eject All Coins
 vendingmachine.gui.single_coin_type_eject_hint=Shift-Click to Extract
 vendingmachine.gui.search=Search
 vendingmachine.gui.required_inputs=Requires:
+vendingmachine.gui.trade_hint=Shift-Click to Purchase
 
 vendingmachine.gui.cooldown_display.second=s
 vendingmachine.gui.cooldown_display.minute=m


### PR DESCRIPTION
1. Fixed structure lib display

<img width="475" height="505" alt="image" src="https://github.com/user-attachments/assets/9a985d81-2fb6-4367-bf5a-4206f35ec87c" />

<img width="565" height="78" alt="image" src="https://github.com/user-attachments/assets/069e56c5-d81c-4f44-80f1-e16800b5ae3c" />


2. Added hint for uplink hatch in tooltip

<img width="906" height="256" alt="image" src="https://github.com/user-attachments/assets/2e852666-a3e5-4d8f-9f5d-a79b13172976" />


3. Added "shift click to purchase" on trade tooltips


<img width="420" height="203" alt="image" src="https://github.com/user-attachments/assets/f9dc56d5-4ca0-4c9e-b7e1-4543595b4fb7" />
